### PR TITLE
chore: fix circleCI conf

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "arrowParens": "always"
   },
   "release": {
-    "branch": "trunk"
+    "branches": [
+      "trunk"
+    ]
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Latest semantic-release upgrade requires the release branches to be listed in an array.

Currently builds fail with
```
[1:08:27 PM] [semantic-release] › ✖  ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).

This may occur if your repository does not have a release branch, such as master.

Your configuration for the problematic branches is [].
```

This PR should fix it.

Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>